### PR TITLE
fix: 나머지 bigint를 tinyint로 수정했습니다

### DIFF
--- a/src/main/java/com/lotto/lotto_simulator/entity/LottoCombination.java
+++ b/src/main/java/com/lotto/lotto_simulator/entity/LottoCombination.java
@@ -21,21 +21,21 @@ public class LottoCombination {
     private Long lotto_id;
 
     @Column(nullable = false)
-    private Long firstNum;
+    private Byte firstNum;
 
     @Column(nullable = false)
-    private Long secondNum;
+    private Byte secondNum;
 
     @Column(nullable = false)
-    private Long thirdNum;
+    private Byte thirdNum;
 
     @Column(nullable = false)
-    private Long fourthNum;
+    private Byte fourthNum;
 
     @Column(nullable = false)
-    private Long fifthNum;
+    private Byte fifthNum;
 
     @Column(nullable = false)
-    private Long sixthNum;
+    private Byte sixthNum;
 
 }

--- a/src/main/java/com/lotto/lotto_simulator/entity/Round.java
+++ b/src/main/java/com/lotto/lotto_simulator/entity/Round.java
@@ -22,29 +22,29 @@ public class Round {
     private Long id;
 
     @Column(nullable = false)
-    private Long bonus;
+    private Byte bonus;
 
     // String? Date? 굳이 Date일 필요가 있나?
     @Column(nullable = false)
     private LocalDateTime date;
 
     @Column(nullable = false)
-    private Long num1;
+    private Byte num1;
 
     @Column(nullable = false)
-    private Long num2;
+    private Byte num2;
 
     @Column(nullable = false)
-    private Long num3;
+    private Byte num3;
 
     @Column(nullable = false)
-    private Long num4;
+    private Byte num4;
 
     @Column(nullable = false)
-    private Long num5;
+    private Byte num5;
 
     @Column(nullable = false)
-    private Long num6;
+    private Byte num6;
 
 
 

--- a/src/main/java/com/lotto/lotto_simulator/service/LottoService.java
+++ b/src/main/java/com/lotto/lotto_simulator/service/LottoService.java
@@ -134,7 +134,7 @@ public class LottoService {
         Round round = roundRepository.findByRound(num).orElseThrow();
         System.out.println("round = " + round);
         //라운드 로또  추첨 번호
-        List<Long> rounds = new ArrayList<>();
+        List<Byte> rounds = new ArrayList<>();
         rounds.add(round.getNum1());
         rounds.add(round.getNum2());
         rounds.add(round.getNum3());
@@ -145,16 +145,16 @@ public class LottoService {
 
         System.out.println("rounds = " + Arrays.toString(rounds.toArray()));
         List<LottoDto> lottos = lottoRepository.search();
-        List<List<Long>> lottoList = new ArrayList<>();
+        List<List<Byte>> lottoList = new ArrayList<>();
 
         for (LottoDto l : lottos) {
-            List<Long> lottoNum = new ArrayList<>();
-            lottoNum.add((long)l.getFirstNum());
-            lottoNum.add((long)l.getSecondNum());
-            lottoNum.add((long)l.getThirdNum());
-            lottoNum.add((long)l.getFourthNum());
-            lottoNum.add((long)l.getFifthNum());
-            lottoNum.add((long)l.getSixthNum());
+            List<Byte> lottoNum = new ArrayList<>();
+            lottoNum.add(l.getFirstNum());
+            lottoNum.add(l.getSecondNum());
+            lottoNum.add(l.getThirdNum());
+            lottoNum.add(l.getFourthNum());
+            lottoNum.add(l.getFifthNum());
+            lottoNum.add(l.getSixthNum());
             lottoList.add(lottoNum);
         }
 
@@ -167,19 +167,19 @@ public class LottoService {
 
         int lottoCnt = 0;
 
-        for (List<Long> l : lottoList) {
+        for (List<Byte> l : lottoList) {
 
-            HashMap<Long, Integer> map = new HashMap<>();
-            for (int i = 0; i < rounds.size(); i++) {
-                map.put(rounds.get(i), map.getOrDefault(rounds.get(i), 0) + 1);
+            HashMap<Byte, Integer> map = new HashMap<>();
+            for (Byte value : rounds) {
+                map.put(value, map.getOrDefault(value, 0) + 1);
             }
-            for (int i = 0; i < l.size(); i++) {
-                map.put(l.get(i), map.getOrDefault(l.get(i), 0) - 1);
+            for (Byte aByte : l) {
+                map.put(aByte, map.getOrDefault(aByte, 0) - 1);
             }
 
 
             int cnt = 0;
-            for (Long key : map.keySet()) {
+            for (Byte key : map.keySet()) {
                 if (map.get(key) > 0) {
                     cnt++;
                 }
@@ -230,7 +230,7 @@ public class LottoService {
 
         // num라운드의 당첨번호 정보를 가져온다.
         Round round = roundRepository.findByRound(num).orElseThrow();
-        List<Long> rounds = new ArrayList<>();
+        List<Byte> rounds = new ArrayList<>();
         rounds.add(round.getNum1());
         rounds.add(round.getNum2());
         rounds.add(round.getNum3());
@@ -239,16 +239,16 @@ public class LottoService {
         rounds.add(round.getNum6());
 
 
-        List<List<Long>> singleLottoNum = new ArrayList<>();
+        List<List<Byte>> singleLottoNum = new ArrayList<>();
 
         for (LottoDto l : lottoList) {
-            List<Long> lottoNum = new ArrayList<>();
-            lottoNum.add(Long.valueOf(l.getFirstNum()));
-            lottoNum.add(Long.valueOf(l.getSecondNum()));
-            lottoNum.add(Long.valueOf(l.getThirdNum()));
-            lottoNum.add(Long.valueOf(l.getFourthNum()));
-            lottoNum.add(Long.valueOf(l.getFifthNum()));
-            lottoNum.add(Long.valueOf(l.getSixthNum()));
+            List<Byte> lottoNum = new ArrayList<>();
+            lottoNum.add(l.getFirstNum());
+            lottoNum.add(l.getSecondNum());
+            lottoNum.add(l.getThirdNum());
+            lottoNum.add(l.getFourthNum());
+            lottoNum.add(l.getFifthNum());
+            lottoNum.add(l.getSixthNum());
             singleLottoNum.add(lottoNum);
         }
 
@@ -259,26 +259,26 @@ public class LottoService {
         int fifthRank = 0;
 
         // 등수와 당첨번호를 모아넣는 Map
-        HashMap<Integer, List<List<Long>>> winLottoMap = new HashMap<>();
-        List<List<Long>> firstList = new ArrayList<>();
-        List<List<Long>> secondList = new ArrayList<>();
-        List<List<Long>> thirdList = new ArrayList<>();
-        List<List<Long>> fourthList = new ArrayList<>();
-        List<List<Long>> fifthList = new ArrayList<>();
+        HashMap<Integer, List<List<Byte>>> winLottoMap = new HashMap<>();
+        List<List<Byte>> firstList = new ArrayList<>();
+        List<List<Byte>> secondList = new ArrayList<>();
+        List<List<Byte>> thirdList = new ArrayList<>();
+        List<List<Byte>> fourthList = new ArrayList<>();
+        List<List<Byte>> fifthList = new ArrayList<>();
 
-        for (List<Long> l : singleLottoNum) {
+        for (List<Byte> l : singleLottoNum) {
 
-            HashMap<Long, Integer> map = new HashMap<>();
-            for (int i = 0; i < rounds.size(); i++) {
-                map.put(rounds.get(i), map.getOrDefault(rounds.get(i), 0) + 1);
+            HashMap<Byte, Integer> map = new HashMap<>();
+            for (Byte value : rounds) {
+                map.put(value, map.getOrDefault(value, 0) + 1);
             }
-            for (int i = 0; i < l.size(); i++) {
-                map.put(l.get(i), map.getOrDefault(l.get(i), 0) - 1);
+            for (Byte aByte : l) {
+                map.put(aByte, map.getOrDefault(aByte, 0) - 1);
             }
 
 
             int cnt = 0;
-            for (Long key : map.keySet()) {
+            for (Byte key : map.keySet()) {
                 if (map.get(key) > 0) {
                     cnt++;
                 }
@@ -349,12 +349,12 @@ public class LottoService {
 
 
                 Lotto game = Lotto.builder()
-                        .firstNum((byte) ((long) lotto.get(0).getFirstNum()))
-                        .secondNum((byte) ((long) lotto.get(0).getSecondNum()))
-                        .thirdNum((byte) ((long) lotto.get(0).getThirdNum()))
-                        .fourthNum((byte) ((long) lotto.get(0).getFourthNum()))
-                        .fifthNum((byte) ((long) lotto.get(0).getFifthNum()))
-                        .sixthNum((byte) ((long) lotto.get(0).getSixthNum()))
+                        .firstNum(lotto.get(0).getFirstNum())
+                        .secondNum(lotto.get(0).getSecondNum())
+                        .thirdNum(lotto.get(0).getThirdNum())
+                        .fourthNum(lotto.get(0).getFourthNum())
+                        .fifthNum(lotto.get(0).getFifthNum())
+                        .sixthNum(lotto.get(0).getSixthNum())
                         .uniqueCode(uuid)
                         .store(stores.get((int) (Math.random() * stores.size())))
                         .build();


### PR DESCRIPTION
round, lotto_combination 테이블의 6개 번호 컬럼을 Byte 형식으로 바꾸고 서비스쪽도 에러가 없도록 수정하였습니다 로컬DB에서 정상으로 작동하는것을 확인하였고 DB에서 아래 SQL명령어를 입력해서 테이블을 수정해주세요 

ALTER TABLE round MODIFY COLUMN bonus tinyint NOT NULL; 
ALTER TABLE round MODIFY COLUMN num1 tinyint NOT NULL; 
ALTER TABLE round MODIFY COLUMN num2 tinyint NOT NULL; 
ALTER TABLE round MODIFY COLUMN num3 tinyint NOT NULL; 
ALTER TABLE round MODIFY COLUMN num4 tinyint NOT NULL; 
ALTER TABLE round MODIFY COLUMN num5 tinyint NOT NULL; 
ALTER TABLE round MODIFY COLUMN num6 tinyint NOT NULL;

ALTER TABLE lotto_combination MODIFY COLUMN first_num tinyint NOT NULL; 
ALTER TABLE lotto_combination MODIFY COLUMN second_num tinyint NOT NULL; 
ALTER TABLE lotto_combination MODIFY COLUMN third_num tinyint NOT NULL; 
ALTER TABLE lotto_combination MODIFY COLUMN fourth_num tinyint NOT NULL; 
ALTER TABLE lotto_combination MODIFY COLUMN fifth_num tinyint NOT NULL; 
ALTER TABLE lotto_combination MODIFY COLUMN sixth_num tinyint NOT NULL;

issue: #32