### PR TITLE
fix: build시 발생하는 warning 해결

### DIFF
--- a/src/main/java/com/lotto/lotto_simulator/controller/responseDto/GambleDto.java
+++ b/src/main/java/com/lotto/lotto_simulator/controller/responseDto/GambleDto.java
@@ -12,9 +12,15 @@ import java.util.List;
 @Builder
 @NoArgsConstructor
 public class GambleDto {
+    @Builder.Default
     private List<List<Byte>> firstList = new ArrayList<>();
+
+    @Builder.Default
     private List<List<Byte>> secondList = new ArrayList<>();
+
+    @Builder.Default
     private List<List<Byte>> thirdList = new ArrayList<>();
+
     private Long fourthRank;
     private Long fifthRank;
     private Integer totalCnt;


### PR DESCRIPTION
@Builder를 사용할 때에 초기화한 필드 값이 존재하면 인식을 못함
GambleDto에 초기화가 필요한 필드 위에 @Builder.Default를 붙임

issue: #73